### PR TITLE
Allow the case of post object to be interrupted as an array value

### DIFF
--- a/includes/acf.php
+++ b/includes/acf.php
@@ -61,8 +61,16 @@ function parse_acf_field( $field, $value, $data = array(), $base_prefix = '' ) {
 			}
 			break;
 		case 'post_object':
-			$post  = get_post( $value );
-			$value = post_data( $post );
+			if (is_array($value)) {
+				$value = array_map(
+					function ($v) {
+						$post  = get_post( $v );
+						return post_data( $post );
+					}, $value);
+			} else {
+				$post  = get_post( $value );
+				$value = post_data( $post );
+			}
 			break;
 		case 'group':
 			$value = parse_group_field( $field, $value, $data, $base_prefix );


### PR DESCRIPTION
A field of type `post_object` with the attribute `multiple` set to true was yielding incorrect data results.


**Example JSON for fields.json**
```json
{
              "label": "Foobar",
              "name": "foobar",
              "type": "post_object",
              "required": 0,
              "conditional_logic": 0,
              "wrapper": {
                "width": "",
                "class": "",
                "id": ""
              },
              "post_type": [
                "foos"
              ],
              "taxonomy": "",
              "allow_null": 0,
              "multiple": 1,
              "return_format": "object",
              "ui": 1
}
```

With multiple posts saved in the acf field the value sent to `parse_acf_field` would have the following shape:
```
[array]
 - WP_Post
 - WP_Post
 - WP_Post
 - ...
```

A call to `get_post` with this array value always returns the first post as [WordPress's native code](https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-post.php#L234) casts it to an integer.

This fix should allow the post object to be able to handle an attribute of `multiple` thus serializing multiple post objects.