### PR TITLE
make elasticsearch settings filterable by adding `ep_settings` hook

### DIFF
--- a/includes/elasticsearch/class-client.php
+++ b/includes/elasticsearch/class-client.php
@@ -512,16 +512,18 @@ SOURCE;
 				),
 			);
 			$mappings = apply_filters( 'ep_mappings', $mappings, $index_type );
+			$settings = array(
+				'mapping' => array(
+					'total_fields' => array(
+						'limit' => 10000,
+					),
+				),
+			);
+			$settings = apply_filters( 'ep_settings', $settings, $index_type );
 			$params   = array(
 				'index' => $new_index,
 				'body'  => array(
-					'settings' => array(
-						'mapping' => array(
-							'total_fields' => array(
-								'limit' => 10000,
-							),
-						),
-					),
+					'settings' => $settings,
 					'mappings' => array(
 						'jsondata' => $mappings,
 					),


### PR DESCRIPTION
`total_fields` is currently hardcoded to a hard limit of 10000. Some apps may need to adjust this value as seen by Nemacolin.

![image](https://user-images.githubusercontent.com/338605/231783326-893ffd2e-1cb3-4c23-bebc-71bdff68dcd9.png)

This update adds a `ep_settings` filter that can be used to adjust settings.

Example usage:
```php
add_filter('ep_settings', function($settings, $index_type) {
  $settings['mapping']['total_fields']['limit'] = 50000;
  return $settings;
}, 10, 2);
```