### PR TITLE
Add Global Options Filters

### DIFF
--- a/elastic-press.php
+++ b/elastic-press.php
@@ -86,30 +86,24 @@ function init() {
  */
 function load() {
 	CustomPostTypes::register_all();
+	register_php_file( 'functions.php' );
 	Options\register_global_options();
 	Fields\register_fields();
-	register_php_files();
+	register_php_file('fields.php');
+	register_php_file('taxonomies.php');
 	do_action( 'ep_after_load' );
 }
 
 /**
  * Register PHP files
  */
-function register_php_files() {
-	$php_files = array(
-		'fields.php',
-		'functions.php',
-		'taxonomies.php',
-	);
-
+function register_php_file($php_file) {
 	foreach ( array( 'cms', 'frontend' ) as $type ) {
-		foreach ( $php_files as $php_file ) {
-			if ( ! isset( Config::$files[ $type ][ $php_file ] ) ) {
-				continue;
-			}
-			foreach ( Config::$files[ $type ][ $php_file ] as $config ) {
-				require_once $config['path'];
-			}
+		if ( ! isset( Config::$files[ $type ][ $php_file ] ) ) {
+			continue;
+		}
+		foreach ( Config::$files[ $type ][ $php_file ] as $config ) {
+			require_once $config['path'];
 		}
 	}
 }

--- a/includes/utils/options.php
+++ b/includes/utils/options.php
@@ -45,6 +45,11 @@ function register_global_options() {
  * @param Array  $fields The array of ACF fields to register.
  */
 function register_global_options_page( $type, $page_name, $fields ) {
+	$skip = apply_filters( 'ep_skip_global_options', false, $type, $page_name, $fields );
+	if ( $skip ) {
+		return;
+	}
+	$fields = apply_filters( 'ep_global_options_fields', $fields, $type, $page_name );
 	register_options_page( 'Global Options', $type, $page_name, $fields );
 }
 


### PR DESCRIPTION
- update php file loading so filters can apply to field configs
- add two filters for global options:
  - `ep_skip_global_options` - allows skipping full global options pages
  - `ep_global_options_fields` - allows filtering global options fields