### PR TITLE
get_image_array image srcset fix

### DIFF
--- a/includes/serializers.php
+++ b/includes/serializers.php
@@ -235,7 +235,7 @@ function get_image_array( $thumbnail_id ) {
 	$image['filename'] = basename( $file );
 	$image['filesize'] = image_filesize( $file );
 	$image['alt']      = get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true );
-	$image['srcset']   = wp_get_attachment_image_srcset( $thumbnail_id ) ?? '';
+	$image['srcset']   = wp_get_attachment_image_srcset( $thumbnail_id ) ?: '';
 	foreach ( get_intermediate_image_sizes() as $size ) {
 		$image['sizes'][ $size ] = wp_get_attachment_image_src( $thumbnail_id, $size )[0];
 	}


### PR DESCRIPTION
ensure image srcset is always a string

> {"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"failed to parse field [featured_image.image.srcset] of type [boolean] in document with id '81538'"}],"type":"mapper_parsing_exception","reason":"failed to parse field [featured_image.image.srcset] of type [boolean] in document with id '81538'","caused_by":{"type":"illegal_argument_exception","reason":"Failed to parse value [https://d1fxo6mb5umqsa.cloudfront.net/wp-content/uploads/2024/05/16110759/Hero-300x167.jpg 300w, https://d1fxo6mb5umqsa.cloudfront.net/wp-content/uploads/2024/05/16110759/Hero-1024x569.jpg 1024w, https://d1fxo6mb5umqsa.cloudfront.net/wp-content/uploads/2024/05/16110759/Hero-768x426.jpg 768w, https://d1fxo6mb5umqsa.cloudfront.net/wp-content/uploads/2024/05/16110759/Hero-1536x853.jpg 1536w, https://d1fxo6mb5umqsa.cloudfront.net/wp-content/uploads/2024/05/16110759/Hero-2048x1137.jpg 2048w] as only [true] or [false] are allowed."}},"status":400}


Before this fix, image srcset could be a boolean.

## Addresses
- kingandpartners/nemacolin#2480